### PR TITLE
Add FXIOS-7471 [v119] Sync and Done button logic in new tab controller

### DIFF
--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -153,11 +153,9 @@ class TabTrayViewController: UIViewController,
     }()
 
     private lazy var bottomToolbarItemsForSync: [UIBarButtonItem] = {
-        if hasSyncableAccount {
-            return [flexibleSpace, syncTabButton]
-        } else {
-            return []
-        }
+        guard hasSyncableAccount else { return [] }
+
+        return [flexibleSpace, syncTabButton]
     }()
     
     private var rightBarButtonItemsForSync: [UIBarButtonItem] {

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -44,6 +44,13 @@ class TabTrayViewController: UIViewController,
     var isSyncTabsPanel: Bool {
         return selectedSegment == .syncedTabs
     }
+    
+    var hasSyncableAccount: Bool {
+        // Temporary. Added for early testing.
+        // Eventually we will update this to use Redux state. -mr
+        guard let profile = (UIApplication.shared.delegate as? AppDelegate)?.profile else { return false }
+        return profile.hasSyncableAccount()
+    }
 
     // iPad Layout
     var isRegularLayout: Bool {
@@ -146,8 +153,20 @@ class TabTrayViewController: UIViewController,
     }()
 
     private lazy var bottomToolbarItemsForSync: [UIBarButtonItem] = {
-        return [flexibleSpace, syncTabButton]
+        if hasSyncableAccount {
+            return [flexibleSpace, syncTabButton]
+        } else {
+            return []
+        }
     }()
+    
+    private var rightBarButtonItemsForSync: [UIBarButtonItem] {
+        if hasSyncableAccount {
+            return [doneButton, fixedSpace, syncTabButton]
+        } else {
+            return [doneButton]
+        }
+    }
 
     init(delegate: TabTrayViewControllerDelegate,
          themeManager: ThemeManager = AppContainer.shared.resolve(),
@@ -272,14 +291,13 @@ class TabTrayViewController: UIViewController,
     }
 
     private func setupToolbarForIpad() {
-        guard !isSyncTabsPanel else {
+        if isSyncTabsPanel {
             navigationItem.leftBarButtonItem = nil
-            navigationItem.rightBarButtonItem = syncTabButton
-            return
+            navigationItem.rightBarButtonItems = rightBarButtonItemsForSync
+        } else {
+            navigationItem.leftBarButtonItem = deleteButton
+            navigationItem.rightBarButtonItems = [doneButton, fixedSpace, newTabButton]
         }
-
-        navigationItem.rightBarButtonItems = [doneButton, fixedSpace, newTabButton]
-        navigationItem.leftBarButtonItem = deleteButton
     }
 
     private func createSegmentedControl(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-7471)

## :bulb: Description
Updates logic for Sync and Done buttons.

👉 Note: this targets @yoanarios 's open PR since it is a small addition to that work.

## :pencil: Checklist
You have to check all boxes before merging
- [x] Filled in the above information (tickets numbers and description of your work)
- [x] Updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] Wrote unit tests and/or ensured the tests suite is passing
- [ ] When working on UI, I checked and implemented accessibility (minimum Dynamic Text and VoiceOver)
- [ ] If needed I updated documentation / comments for complex code and public methods

